### PR TITLE
Add CMake build files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(thc-chess)
 
 # specify the include directory for the outer project
 set(THC_CHESS_INCLUDE ${PROJECT_SOURCE_DIR}/src PARENT_SCOPE)
+# specify a release build
+add_definitions(-DKILL_DEBUG_COMPLETELY)
 # gather all sources
 file(GLOB THC_CHESS_SRCS ${PROJECT_SOURCE_DIR}/src/*.cpp ${PROJECT_SOURCE_DIR}/src/*.h)
 # don't compile twice the unified cpp objects, and remove testing from the final library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.17)
+
+project(thc-chess)
+
+# specify the include directory for the outer project
+set(THC_CHESS_INCLUDE ${PROJECT_SOURCE_DIR}/src PARENT_SCOPE)
+# gather all sources
+file(GLOB THC_CHESS_SRCS ${PROJECT_SOURCE_DIR}/src/*.cpp ${PROJECT_SOURCE_DIR}/src/*.h)
+# don't compile twice the unified cpp objects, and remove testing from the final library
+list(REMOVE_ITEM THC_CHESS_SRCS ${PROJECT_SOURCE_DIR}/src/thc.cpp ${PROJECT_SOURCE_DIR}/src/thc-regen.cpp ${PROJECT_SOURCE_DIR}/src/test-framework.cpp)
+# define both a static and shared library
+add_library(thc_chess SHARED ${THC_CHESS_SRCS})
+add_library(thc_chess_static STATIC ${THC_CHESS_SRCS})

--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ are the only files you need EXCEPT, unfortunately DebugPrintf.h and Portability.
 Tarrasch Chess GUI files and are also needed just at the moment. The presence of DebugPrintf.h
 requires that the user contribute a DebugPrintfInner() or similar function.
 
+CMake Build
+=====
+
+If you instead use CMake as a build system, you may prefer adding the library to your project
+as a CMake submodule. `CMakeLists.txt` provides the variable `THC_CHESS_INCLUDE` for the headers
+include directory and the libraries `thc_chess` (shared) and `thc_chess_static` (static).
+
+Usage example:
+```cmake
+add_subdirectory("${PROJECT_SOURCE_DIR}/path/to/library" EXCLUDE_FROM_ALL)
+include_directories(${THC_CHESS_INCLUDE})
+target_link_libraries(your_binary_name thc_chess_static) # or thc_chess for dynamic linking
+```
+
 To Do
 =====
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <string>
 #include <stdarg.h>  // For va_start, etc.
+#include <cstring>
 #include "util.h"
 
 namespace util


### PR DESCRIPTION
Though the `README` states that the library is mainly used through the single unified `.h` and `.cpp` files, i found it useful to write a CMake build file for using the library in a private project of mine; so I though i could share it.