### PR TITLE
Don't do unnecassary computation for `GenLegalMoveList(list)`

### DIFF
--- a/src/ChessRules.cpp
+++ b/src/ChessRules.cpp
@@ -235,7 +235,6 @@ void ChessRules::GenLegalMoveList( MOVELIST *list )
 {
     int i, j;
     bool okay;
-    TERMINAL terminal_score;
     MOVELIST list2;
 
     // Generate all moves, including illegal (eg put king in check) moves
@@ -245,7 +244,7 @@ void ChessRules::GenLegalMoveList( MOVELIST *list )
     for( i=j=0; i<list2.count; i++ )
     {
         PushMove( list2.moves[i] );
-        okay = Evaluate(terminal_score);
+        okay = Evaluate();
         PopMove( list2.moves[i] );
         if( okay )
             list->moves[j++] = list2.moves[i];
@@ -1293,6 +1292,13 @@ bool ChessRules::AttackedSquare( Square square, bool enemy_is_white )
 /****************************************************************************
  * Evaluate a position, returns bool okay (not okay means illegal position)
  ****************************************************************************/
+bool ChessRules::Evaluate()
+{
+    Square enemy_king = (Square)(white ? bking_square : wking_square);
+    // Enemy king is attacked and our move, position is illegal
+    return !AttackedPiece(enemy_king);
+}
+
 bool ChessRules::Evaluate( TERMINAL &score_terminal )
 {
 	return( Evaluate(NULL,score_terminal) );

--- a/src/ChessRules.h
+++ b/src/ChessRules.h
@@ -74,6 +74,7 @@ public:
     bool IsInsufficientDraw( bool white_asks, DRAWTYPE &result );
 
     // Evaluate a position, returns bool okay (not okay means illegal position)
+    bool Evaluate();
     bool Evaluate( TERMINAL &score_terminal );
 
     // Is a square is attacked by enemy ?


### PR DESCRIPTION
Currently `GenLegalMoveList(list)` does computation for the state of next position(check, checkmate, stalemate) which is not required. This change speeds up the function call by 10 times.

Let me know if I should make changes in the combined files like `thc-regen.cpp`.