### PR TITLE
Adding an include to prevent build failure on initial cmake integration.

### DIFF
--- a/src/ChessDefs.h
+++ b/src/ChessDefs.h
@@ -7,6 +7,8 @@
 #ifndef CHESSDEFS_H
 #define CHESSDEFS_H
 
+#include <stdint.h>
+
 // Simple definition to aid platform portability (only remains of former Portability.h)
 int strcmp_ignore( const char *s, const char *t ); // return 0 if case-insensitive match
 


### PR DESCRIPTION
Running a simple first-pass integration of thc using cmake leads to a build failure, due to a missing include in ChessDefs.h.

This PR adds the include.

(cmake, gcc)